### PR TITLE
Enable postmap to use template

### DIFF
--- a/manifests/postmap.pp
+++ b/manifests/postmap.pp
@@ -2,10 +2,23 @@
 # = Define: postfix::postmap
 #
 define postfix::postmap (
-  $source  = undef,
-  $content = undef,
-  $destdir = '/etc/postfix',
+  $source   = undef,
+  $content  = undef,
+  $template = undef,
+  $destdir  = '/etc/postfix',
 ){
+
+  if ($source and $content) or ($source and $template) or ($content and $template) {
+    fail('Only one of $source, $content and $template can be specified.')
+  } elsif ! $source and ! $content and ! $template {
+    fail('One of $source, $content or $template must be specified.')
+  }
+
+  if ( $template ) {
+    $content_real = template($template)
+  } else {
+    $content_real = $content
+  }
 
   file { "${destdir}/${title}":
     ensure  => file,
@@ -13,7 +26,7 @@ define postfix::postmap (
     group   => root,
     mode    => '0644',
     source  => $source,
-    content => $content,
+    content => $content_real,
     notify  => Exec["postfix_update_postmap_${title}"],
   }
 

--- a/spec/acceptance/postmap_spec.rb
+++ b/spec/acceptance/postmap_spec.rb
@@ -6,10 +6,13 @@ describe 'postfix::postmap define' do
     if (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemmajrelease') == '14.04')
       shell("echo localhost | sudo tee /etc/mailname")
     end
-    
+
     shell('rm -f /tmp/virtual_local')
     shell('echo "valentina  catchmail" >> /tmp/virtual_local')
     shell('echo "zuzanna    catchmail" >> /tmp/virtual_local')
+
+    shell('rm -f /tmp/virtual_local.erb')
+    shell('echo "<%= @postfix_test_var %>" >> /tmp/virtual_local.erb')
   end
 
   context '=> content text <=' do
@@ -52,6 +55,45 @@ describe 'postfix::postmap define' do
       its(:content) { should match 'valentina' }
       its(:content) { should match 'zuzanna'   }
       its(:content) { should match 'catchmail' }
+    end
+  end
+
+  context '=> template <=' do
+    it 'should add text from template' do
+      pp = <<-EOS
+          class { '::postfix': }
+	  $postfix_test_var = 'some_test_string   some@email.com'
+          ::postfix::postmap { 'virtual_local':
+            template => '/tmp/virtual_local.erb',
+          }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stderr).not_to match(/error/i)
+      end
+    end
+
+    describe file("/etc/postfix/virtual_local") do
+      it { should be_file }
+      its(:content) { should match 'some_test_string' }
+      its(:content) { should match 'some@email.com'   }
+    end
+  end
+
+  context '=> template and content <=' do
+    it 'should report error' do
+      pp = <<-EOS
+          class { '::postfix': }
+	  $postfix_test_var = 'some_test_string   some@email.com'
+          ::postfix::postmap { 'virtual_local':
+            template => '/tmp/virtual_local.erb',
+	    content  => "foobar",
+          }
+      EOS
+
+      apply_manifest(pp, :expect_failures => true) do |r|
+        expect(r.stderr).to match(/error/i)
+      end
     end
   end
 


### PR DESCRIPTION
Hiera only accepts data and can't eval functions like template(), hence we can't pass template to `postfix::postmap` define.

This PR fixes that.